### PR TITLE
Use github.com/openssl instead of openssl.org

### DIFF
--- a/iSSH2-openssl.sh
+++ b/iSSH2-openssl.sh
@@ -37,7 +37,7 @@ mkdir -p "$LIBSSLDIR"
 
 LIBSSL_TAR="openssl-$LIBSSL_VERSION.tar.gz"
 
-downloadFile "https://www.openssl.org/source/$LIBSSL_TAR" "$LIBSSLDIR/$LIBSSL_TAR"
+downloadFile "https://github.com/openssl/openssl/releases/download/openssl-$LIBSSL_VERSION/$LIBSSL_TAR" "$LIBSSLDIR/$LIBSSL_TAR"
 
 LIBSSLSRC="$LIBSSLDIR/src/"
 mkdir -p "$LIBSSLSRC"

--- a/iSSH2.sh
+++ b/iSSH2.sh
@@ -60,7 +60,7 @@ getLibssh2Version () {
 
 getOpensslVersion () {
   if type git >/dev/null 2>&1; then
-    LIBSSL_VERSION=`git ls-remote --tags git://git.openssl.org/openssl.git | egrep "OpenSSL(_[0-9])+[a-zA-Z]?$" | cut -f 2,3,4 -d _ | sort -t _ -r | head -n 1 | tr _ .`
+    LIBSSL_VERSION=`git ls-remote --tags https://github.com/openssl/openssl.git | egrep "OpenSSL(_[0-9])+[a-zA-Z]?$" | cut -f 2,3,4 -d _ | sort -t _ -r | head -n 1 | tr _ .`
     LIBSSL_AUTO=true
   else
     >&2 echo "Install git to automatically get the latest OpenSSL version or use the --openssl argument"


### PR DESCRIPTION
When executing the script, it hangs forever and finally times out when trying to fetch then OpenSSL version.

As mentioned in this issue https://github.com/openssl/openssl/issues/25191, `git.openssl.org` seems to have been deprecated and/or not used for a while.

Using the HTTPS GitHub URL fixes the timeout.